### PR TITLE
Setup vscode debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "unit test",
+            "request": "launch",
+            "runtimeArgs": [
+                "run-script",
+                "test",
+                "---",
+                "--runInBand"
+            ],
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "pwa-node",
+            "envFile": "${workspaceFolder}/.env.debug",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        }
+    ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,14 @@ export default {
     '**/__tests__/**/*.+(ts|tsx|js)',
     '**/?(*.)+(spec|test).+(ts|tsx|js)'
   ],
+  collectCoverage: true,
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/src/types/'
+  ],
   transform: {},
+  testEnvironment: 'jest-environment-node',
   // https://kulshekhar.github.io/ts-jest/docs/next/guides/esm-support/
   preset: 'ts-jest/presets/default-esm',
   extensionsToTreatAsEsm: ['.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1586,6 +1586,11 @@
       "integrity": "sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA==",
       "dev": true
     },
+    "@types/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-ARATsLdrGPUnaBvxLhUlnltcMgn7pQG312S8ccdYlnyijabrX9RN/KN/iGj9Am96CoW8e/K9628BA7Bv4XHdrA=="
+    },
     "@types/prettier": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
@@ -2702,6 +2707,21 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
+    "hast-util-from-parse5": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.0.tgz",
+      "integrity": "sha512-m8yhANIAccpU4K6+121KpPP55sSl9/samzQSQGpb0mTExcNh2WlvjtMwSWFhg6uqD4Rr6Nfa8N6TMypQM51rzQ==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/parse5": "^6.0.0",
+        "@types/unist": "^2.0.0",
+        "hastscript": "^7.0.0",
+        "property-information": "^6.0.0",
+        "vfile": "^5.0.0",
+        "vfile-location": "^4.0.0",
+        "web-namespaces": "^2.0.0"
+      }
+    },
     "hast-util-is-element": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.1.tgz",
@@ -2709,6 +2729,14 @@
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.0.tgz",
+      "integrity": "sha512-AyjlI2pTAZEOeu7GeBPZhROx0RHBnydkQIXlhnFzDi0qfXTmGUWoCYZtomHbrdrheV4VFUlPcfJ6LMF5T6sQzg==",
+      "requires": {
+        "@types/hast": "^2.0.0"
       }
     },
     "hast-util-to-html": {
@@ -2732,6 +2760,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz",
       "integrity": "sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg=="
+    },
+    "hastscript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.0.2.tgz",
+      "integrity": "sha512-uA8ooUY4ipaBvKcMuPehTAB/YfFLSSzCwFSwT6ltJbocFUKH/GDHLN+tflq7lSRf9H86uOuxOFkh1KgIy3Gg2g==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -4293,8 +4333,7 @@
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "path-exists": {
       "version": "4.0.0",
@@ -5172,6 +5211,15 @@
         "vfile-message": "^3.0.0"
       }
     },
+    "vfile-location": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.0.1.tgz",
+      "integrity": "sha512-JDxPlTbZrZCQXogGheBHjbRWjESSPEak770XwWPfw5mTc1v1nWGLB/apzZxsx8a0SJVfF8HK8ql8RD308vXRUw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "vfile": "^5.0.0"
+      }
+    },
     "vfile-message": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.2.tgz",
@@ -5207,6 +5255,11 @@
       "requires": {
         "makeerror": "1.0.x"
       }
+    },
+    "web-namespaces": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.0.tgz",
+      "integrity": "sha512-dE7ELZRVWh0ceQsRgkjLgsAvwTuv3kcjSY/hLjqL0llleUlQBDjE9JkB9FCBY5F2mnFEwiyJoowl8+NVGHe8dw=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2523,6 +2523,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fault": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.0.tgz",
+      "integrity": "sha512-JsDj9LFcoC+4ChII1QpXPA7YIaY8zmqPYw7h9j5n7St7a0BBKfNnwEBAUQRBx70o2q4rs+BeSNHk8Exm6xE7fQ==",
+      "requires": {
+        "format": "^0.2.0"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2561,6 +2569,11 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -3847,6 +3860,14 @@
         "uvu": "^0.5.0"
       }
     },
+    "mdast-util-frontmatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.0.tgz",
+      "integrity": "sha512-7itKvp0arEVNpCktOET/eLFAYaZ+0cNjVtFtIPxgQ5tV+3i+D4SDDTjTzPWl44LT59PC+xdx+glNTawBdF98Mw==",
+      "requires": {
+        "micromark-extension-frontmatter": "^1.0.0"
+      }
+    },
     "mdast-util-to-markdown": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.3.tgz",
@@ -3917,6 +3938,16 @@
         "micromark-util-types": "^1.0.1",
         "parse-entities": "^3.0.0",
         "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-frontmatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.0.0.tgz",
+      "integrity": "sha512-EXjmRnupoX6yYuUJSQhrQ9ggK0iQtQlpi6xeJzVD5xscyAI+giqco5fdymayZhJMbIFecjnE2yz85S9NzIgQpg==",
+      "requires": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
       }
     },
     "micromark-factory-destination": {
@@ -4532,6 +4563,17 @@
         "@types/mdast": "^3.0.0",
         "remark-parse": "^10.0.0",
         "remark-stringify": "^10.0.0",
+        "unified": "^10.0.0"
+      }
+    },
+    "remark-frontmatter": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.0.tgz",
+      "integrity": "sha512-0J+2czWAS9sz9baJJel4tTUnNhMI7wYgih99Hxhdeq2GpdI1Ctu0iol6zAsWw5xa+jLsZXNiwEnnJAJo3XX3hw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-frontmatter": "^1.0.0",
+        "micromark-extension-frontmatter": "^1.0.0",
         "unified": "^10.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1508,6 +1508,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1515,6 +1523,14 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/hast": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
+      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "requires": {
+        "@types/unist": "*"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -1551,6 +1567,19 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "@types/mdast": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
+      "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+    },
     "@types/node": {
       "version": "16.11.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.1.tgz",
@@ -1568,6 +1597,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@types/yargs": {
       "version": "17.0.4",
@@ -1795,6 +1829,11 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
+    "bail": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.1.tgz",
+      "integrity": "sha512-d5FoTAr2S5DSUPKl85WNm2yUwsINN8eidIdIwsOge2t33DaOfOdSmmsI11jMN3GmALCXaw+Y6HMVHDzePshFAA=="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1949,6 +1988,11 @@
       "integrity": "sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w==",
       "dev": true
     },
+    "ccount": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.0.tgz",
+      "integrity": "sha512-VOR0NWFYX65n9gELQdcpqsie5L5ihBXuZGAgaPEp/U7IOSjnPMEH6geE+2f6lcekaNEfWzAHS45mPvSo5bqsUA=="
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1981,6 +2025,26 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "character-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.0.tgz",
+      "integrity": "sha512-oHqMj3eAuJ77/P5PaIRcqk+C3hdfNwyCD2DAUcD5gyXkegAuF2USC40CEqPscDk4I8FRGMTojGJQkXDsN5QlJA=="
+    },
+    "character-entities-html4": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.0.0.tgz",
+      "integrity": "sha512-dwT2xh5ZhUAjyP96k57ilMKoTQyASaw9IAMR9U5c1lCu2RUni6O6jxfpUEdO2RcPT6TJFvr8pqsbami4Jk+2oA=="
+    },
+    "character-entities-legacy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-2.0.0.tgz",
+      "integrity": "sha512-YwaEtEvWLpFa6Wh3uVLrvirA/ahr9fki/NUd/Bd4OR6EdJ8D22hovYQEOUCBfQfcqnC4IAMGMsHXY1eXgL4ZZA=="
+    },
+    "character-reference-invalid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.0.tgz",
+      "integrity": "sha512-pE3Z15lLRxDzWJy7bBHBopRwfI20sbrMVLQTC7xsPglCHf4Wv1e167OgYAFP78co2XlhojDyAqA+IAJse27//g=="
     },
     "chokidar": {
       "version": "3.5.2",
@@ -2083,6 +2147,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comma-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2200,7 +2269,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -2255,6 +2323,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -2427,6 +2500,11 @@
           "dev": true
         }
       }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2624,6 +2702,37 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
+    "hast-util-is-element": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.1.tgz",
+      "integrity": "sha512-ag0fiZfRWsPiR1udvnSbaazJLGv8qd8E+/e3rW8rUZhbKG4HNJmFL4QkEceN+22BgE+uozXY30z/s+2dL6Z++g==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "hast-util-to-html": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.2.tgz",
+      "integrity": "sha512-ipLhUTMyyJi9F/LXaNDG9BrRdshP6obCfmUZYbE/+T639IdzqAOkKN4DyrEyID0gbb+rsC3PKf0XlviZwzomhw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "html-void-elements": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-is": "^5.0.0"
+      }
+    },
+    "hast-util-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz",
+      "integrity": "sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg=="
+    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -2638,6 +2747,11 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "html-void-elements": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.0.tgz",
+      "integrity": "sha512-4OYzQQsBt0G9bJ/nM9/DDsjm4+fVdzAaPJJcWk5QwA3GIAPxQEeOR0rsI8HbDHQz5Gta8pVvGnnTNSbZVEVvkQ=="
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -2731,6 +2845,20 @@
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
+    "is-alphabetical": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.0.tgz",
+      "integrity": "sha512-5OV8Toyq3oh4eq6sbWTYzlGdnMT/DPI5I0zxUBxjiigQsZycpkKF3kskkao3JyYGuYDHvhgJF+DrjMQp9SX86w=="
+    },
+    "is-alphanumerical": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.0.tgz",
+      "integrity": "sha512-t+2GlJ+hO9yagJ+jU3+HSh80VKvz/3cG2cxbGGm4S0hjKuhWQXgPVUVOZz3tqZzMjhmphZ+1TIJTlRZRoe6GCQ==",
+      "requires": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      }
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2739,6 +2867,11 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-ci": {
       "version": "3.0.0",
@@ -2757,6 +2890,11 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-decimal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.0.tgz",
+      "integrity": "sha512-QfrfjQV0LjoWQ1K1XSoEZkTAzSa14RKVMa5zg3SdAfzEmQzRM4+tbSFWb78creCeA9rNBzaZal92opi1TwPWZw=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -2778,6 +2916,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-hexadecimal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.0.tgz",
+      "integrity": "sha512-vGOtYkiaxwIiR0+Ng/zNId+ZZehGfINwTzdrDqc6iubbnQWhnPuYymOzOKUDqa2cSl59yHnEh2h6MvRLQsyNug=="
     },
     "is-installed-globally": {
       "version": "0.4.0",
@@ -2812,6 +2955,11 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
+    },
+    "is-plain-obj": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+      "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -3588,6 +3736,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "longest-streak": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.0.tgz",
+      "integrity": "sha512-XhUjWR5CFaQ03JOP+iSDS9koy8T5jfoImCZ4XprElw3BXsSk4MpVYOLw/6LTDKZhO13PlAXnB5gS4MHQTpkSOw=="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -3635,11 +3788,261 @@
         "tmpl": "1.0.x"
       }
     },
+    "mdast-util-from-markdown": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.0.4.tgz",
+      "integrity": "sha512-BlL42o885QO+6o43ceoc6KBdp/bi9oYyamj0hUbeu730yhP1WDC7m2XYSBfmQkOb0TdoHSAJ3de3SMqse69u+g==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "parse-entities": "^3.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "mdast-util-to-markdown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.3.tgz",
+      "integrity": "sha512-040jJYtjOUdbvYAXCfPrpLJRdvMOmR33KRqlhT4r+fEbVM+jao1RMbA8RmGeRmw8RAj3vQ+HvhIaJPijvnOwCg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+      "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "micromark": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.7.tgz",
+      "integrity": "sha512-67ipZ2CzQVsDyH1kqNLh7dLwe5QMPJwjFBGppW7JCLByaSc6ZufV0ywPOxt13MIDAzzmj3wctDL6Ov5w0fOHXw==",
+      "requires": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "parse-entities": "^3.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-core-commonmark": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.3.tgz",
+      "integrity": "sha512-0E8aE27v0DYHPk40IxzhCdXnZWQuvZ6rbflrx1u8ZZAUJEB48o0fgLXA5+yMab28yXT+mi1Q4LXdsI4oGS6Vng==",
+      "requires": {
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "parse-entities": "^3.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-destination": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
+      "integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-label": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
+      "integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-space": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
+      "integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-title": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
+      "integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-whitespace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
+      "integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
+      "integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-chunked": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
+      "integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-classify-character": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
+      "integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-combine-extensions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
+      "integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-numeric-character-reference": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
+      "integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.1.tgz",
+      "integrity": "sha512-Wf3H6jLaO3iIlHEvblESXaKAr72nK7JtBbLLICPwuZc3eJkMcp4j8rJ5Xv1VbQWMCWWDvKUbVUbE2MfQNznwTA==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "parse-entities": "^3.0.0"
+      }
+    },
+    "micromark-util-encode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.0.tgz",
+      "integrity": "sha512-cJpFVM768h6zkd8qJ1LNRrITfY4gwFt+tziPcIf71Ui8yFzY9wG3snZQqiWVq93PG4Sw6YOtcNiKJfVIs9qfGg=="
+    },
+    "micromark-util-html-tag-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.0.0.tgz",
+      "integrity": "sha512-NenEKIshW2ZI/ERv9HtFNsrn3llSPZtY337LID/24WeLqMzeZhBEE6BQ0vS2ZBjshm5n40chKtJ3qjAbVV8S0g=="
+    },
+    "micromark-util-normalize-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
+      "integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-resolve-all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
+      "integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
+      "requires": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz",
+      "integrity": "sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-subtokenize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
+      "integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.0.tgz",
+      "integrity": "sha512-NZA01jHRNCt4KlOROn8/bGi6vvpEmlXld7EHcRH+aYWUfL3Wc8JLUNNlqUMKa0hhz6GrpUWsHtzPmKof57v0gQ=="
+    },
+    "micromark-util-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.1.tgz",
+      "integrity": "sha512-UT0ylWEEy80RFYzK9pEaugTqaxoD/j0Y9WhHpSyitxd99zjoQz7JJ+iKuhPAgOW2MiPSUAx+c09dcqokeyaROA=="
     },
     "micromatch": {
       "version": "4.0.4",
@@ -3693,11 +4096,15 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3870,6 +4277,19 @@
         }
       }
     },
+    "parse-entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.0.0.tgz",
+      "integrity": "sha512-AJlcIFDNPEP33KyJLguv0xJc83BNvjxwpuUIcetyXUsLpVXAUCePJ5kIoYtEN2R1ac0cYaRu/vk9dVFkewHQhQ==",
+      "requires": {
+        "character-entities": "^2.0.0",
+        "character-entities-legacy": "^2.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      }
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -3978,6 +4398,11 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "property-information": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.0.1.tgz",
+      "integrity": "sha512-F4WUUAF7fMeF4/JUFHNBWDaKDXi2jbvqBW/y6o5wsf3j19wTZ7S60TmtB5HoBhtgw7NKQRMWuz5vk2PR0CygUg=="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -4060,6 +4485,37 @@
         "rc": "^1.2.8"
       }
     },
+    "remark": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.1.tgz",
+      "integrity": "sha512-7zLG3u8EUjOGuaAS9gUNJPD2j+SqDqAFHv2g6WMpE5CU9rZ6e3IKDM12KHZ3x+YNje+NMAuN55yx8S5msGSx7Q==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-stringify": "^10.0.0",
+        "unified": "^10.0.0"
+      }
+    },
+    "remark-parse": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.0.tgz",
+      "integrity": "sha512-07ei47p2Xl7Bqbn9H2VYQYirnAFJPwdMuypdozWsSbnmrkgA2e2sZLZdnDNrrsxR4onmIzH/J6KXqKxCuqHtPQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      }
+    },
+    "remark-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.1.tgz",
+      "integrity": "sha512-380vOu9EHqRTDhI9RlPU2EKY1abUDEmxw9fW7pJ/8Jr1izk0UcdnZB30qiDDRYi6pGn5FnVf9Wd2iUeCWTqM7Q==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4112,6 +4568,14 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "sade": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+      "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+      "requires": {
+        "mri": "^1.1.0"
       }
     },
     "safe-buffer": {
@@ -4192,6 +4656,11 @@
         "source-map": "^0.6.0"
       }
     },
+    "space-separated-tokens": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz",
+      "integrity": "sha512-ekwEbFp5aqSPKaqeY1PGrlGQxPNaq+Cnx4+bE2D8sciBQrHpbwoBbawqTN2+6jPs9IdWxxiUcN0K2pkczD3zmw=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4270,6 +4739,15 @@
             "ansi-regex": "^5.0.0"
           }
         }
+      }
+    },
+    "stringify-entities": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.1.tgz",
+      "integrity": "sha512-gmMQxKXPWIO3NXNSPyWNhlYcBNGpPA/487D+9dLPnU4xBnIrnHdr8cv5rGJOS/1BRxEXRb7uKwg7BA36IWV7xg==",
+      "requires": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -4386,6 +4864,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "totalist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ=="
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -4414,6 +4897,11 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "trough": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.0.2.tgz",
+      "integrity": "sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w=="
     },
     "ts-jest": {
       "version": "27.0.7",
@@ -4512,6 +5000,20 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "unified": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.0.tgz",
+      "integrity": "sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      }
+    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -4519,6 +5021,38 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+      "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+    },
+    "unist-util-stringify-position": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
+      "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-visit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+      "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+      "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
       }
     },
     "universalify": {
@@ -4584,6 +5118,30 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "uvu": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.2.tgz",
+      "integrity": "sha512-m2hLe7I2eROhh+tm3WE5cTo/Cv3WQA7Oc9f7JB6uWv+/zVKvfAm53bMyOoGOSZeQ7Ov2Fu9pLhFr7p07bnT20w==",
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3",
+        "totalist": "^2.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+        },
+        "kleur": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+          "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+        }
+      }
+    },
     "v8-to-istanbul": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
@@ -4601,6 +5159,26 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
+      }
+    },
+    "vfile": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.1.1.tgz",
+      "integrity": "sha512-sfI+3MnGUodvAE2s3hXCcJxhcymXQgekdgqNf9WMcmWtZU65tPMaml5eGYREJfMJGHr4/0GPZgrN3UMgWjHXSQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      }
+    },
+    "vfile-message": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.2.tgz",
+      "integrity": "sha512-UUjZYIOg9lDRwwiBAuezLIsu9KlXntdxwG+nXnjuQAHvBpcX3x0eN8h+I7TkY5nkCXj+cWVp4ZqebtGBvok8ww==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
       }
     },
     "w3c-hr-time": {
@@ -4779,6 +5357,11 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
+    },
+    "zwitch": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
+      "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "npm run build && node dist/main.js",
     "build": "npm run clean && tsc && rimraf dist/test && mv dist/src/* dist/ && rimraf dist/src",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "clean": "rimraf \"dist/*\"",
     "upgrade-interactive": "npm-check --update",
     "csb:test": "npm test -- --runInBand --watchAll"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "csb:test": "npm test -- --runInBand --watchAll"
   },
   "dependencies": {
+    "hast-util-from-parse5": "^7.1.0",
     "hast-util-to-html": "^8.0.2",
+    "parse5": "^6.0.1",
     "remark": "^14.0.1",
     "unified": "^10.1.0",
     "unist-util-visit-parents": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "hast-util-to-html": "^8.0.2",
     "parse5": "^6.0.1",
     "remark": "^14.0.1",
+    "remark-frontmatter": "^4.0.0",
     "unified": "^10.1.0",
     "unist-util-visit-parents": "^5.1.0",
     "yargs": "^17.2.1"

--- a/package.json
+++ b/package.json
@@ -37,11 +37,16 @@
     "csb:test": "npm test -- --runInBand --watchAll"
   },
   "dependencies": {
+    "hast-util-to-html": "^8.0.2",
+    "remark": "^14.0.1",
+    "unified": "^10.1.0",
+    "unist-util-visit-parents": "^5.1.0",
     "yargs": "^17.2.1"
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.1",
+    "@types/unist": "^2.0.6",
     "@types/yargs": "^17.0.4",
     "jest": "^27.3.0",
     "nodemon": "^2.0.13",

--- a/src/alt-attrs.ts
+++ b/src/alt-attrs.ts
@@ -1,0 +1,90 @@
+import parse5 from 'parse5'
+import { fromParse5 } from 'hast-util-from-parse5'
+import { Element } from 'hast'
+import { Node } from 'unist'
+import { Properties } from 'hast'
+import { unified } from 'unified'
+
+export type ExtractAttrs = {
+  source: string
+  extracted: boolean
+  surrounded: [string, string]
+  start: string
+  attrs: string
+  end: string
+}
+
+type AttrsResult = {
+  alt: string
+  properties?: Properties
+  query?: string
+  modifiers?: string
+}
+
+export function decodeAttrs(s: string): Properties {
+  const dummy = `<dummy ${s}/>`
+  const p5ast = parse5.parseFragment(String(dummy), {
+    sourceCodeLocationInfo: true
+  })
+  const n: Node = fromParse5(p5ast)
+  if ((n.type = 'element')) {
+    const root: Element = n as Element
+    const dummy = root.children[0]
+    if (
+      root.children.length === 1 &&
+      dummy.type === 'element' &&
+      dummy.tagName === 'dummy' &&
+      dummy.children.length === 0
+    ) {
+      return dummy.properties || {}
+    }
+  }
+  throw new Error('extractAttrs: invalid attrs has injected')
+  //throw new Error(`extractAttrs: invalid attrs has injected: ${s}`)
+}
+
+const extractRegExp = /(^[^#]*)#([^#]+)#(.*$)/
+export function extractAttrs(alt: string): ExtractAttrs {
+  const s = alt.match(extractRegExp)
+  if (s) {
+    return {
+      source: alt,
+      extracted: true,
+      surrounded: ['#', '#'],
+      start: s[1],
+      attrs: s[2],
+      end: s[3]
+    }
+  }
+  return {
+    source: alt,
+    extracted: false,
+    surrounded: ['', ''],
+    start: '',
+    attrs: '',
+    end: ''
+  }
+}
+
+const dimRegExp = /^d:(\d+)x(\d+)$/
+export function attrs(alt: string): AttrsResult {
+  // Properties {
+  const e = extractAttrs(alt)
+  if (e.extracted) {
+    const properties: Properties = {}
+    Object.entries(decodeAttrs(e.attrs)).forEach(([k, v]) => {
+      const dm = k.match(dimRegExp)
+      if (dm) {
+        properties.width = parseInt(dm[1], 10)
+        properties.height = parseInt(dm[2], 10)
+        return
+      }
+      properties[k] = v
+    })
+    return {
+      alt: `${e.start}${e.end}`,
+      properties
+    }
+  }
+  return { alt }
+}

--- a/src/alt-attrs.ts
+++ b/src/alt-attrs.ts
@@ -3,7 +3,6 @@ import { fromParse5 } from 'hast-util-from-parse5'
 import { Element } from 'hast'
 import { Node } from 'unist'
 import { Properties } from 'hast'
-import { unified } from 'unified'
 
 export type ExtractAttrs = {
   source: string

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,9 @@
 import { Readable, Writable } from 'stream'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
+import remarkFrontmatter from 'remark-frontmatter'
 import stringify from 'remark-stringify'
+
 import { remarkImageSalt } from './image-salt.js'
 
 type Opts = {
@@ -24,6 +26,7 @@ const cli = async ({
     })
     const m = await unified()
       .use(remarkParse)
+      .use(remarkFrontmatter, ['yaml', 'toml'])
       .use(remarkImageSalt, { tagName })
       .use(stringify)
       .freeze()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,21 +3,15 @@ import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkFrontmatter from 'remark-frontmatter'
 import stringify from 'remark-stringify'
-
-import { remarkImageSalt } from './image-salt.js'
+import { remarkImageSalt, RemarkImageSaltOptions } from './image-salt.js'
 
 type Opts = {
   stdin: Readable
   stdout: Writable
   stderr: Writable
-  tagName: string
-}
-const cli = async ({
-  stdin,
-  stdout,
-  stderr,
-  tagName
-}: Opts): Promise<number> => {
+} & Required<RemarkImageSaltOptions>
+const cli = async (opts: Opts): Promise<number> => {
+  const { stdin, stdout, stderr, ...imageSaltOpts } = opts
   try {
     let source = ''
     await new Promise((resolve) => {
@@ -27,7 +21,7 @@ const cli = async ({
     const m = await unified()
       .use(remarkParse)
       .use(remarkFrontmatter, ['yaml', 'toml'])
-      .use(remarkImageSalt, { tagName })
+      .use(remarkImageSalt, { ...imageSaltOpts })
       .use(stringify)
       .freeze()
       .process(source)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ type Opts = {
   stdin: Readable
   stdout: Writable
   stderr: Writable
-} & Required<RemarkImageSaltOptions>
+} & RemarkImageSaltOptions
 const cli = async (opts: Opts): Promise<number> => {
   const { stdin, stdout, stderr, ...imageSaltOpts } = opts
   try {

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -4,7 +4,7 @@ import { Parent, Image, HTML } from 'mdast'
 import { Element, Properties } from 'hast'
 import { visitParents } from 'unist-util-visit-parents'
 import { toHtml } from 'hast-util-to-html'
-import { attrs } from './alt-attrs.js'
+import { attrs, decodeAttrs } from './alt-attrs.js'
 import { editQuery, toModifiers } from './query.js'
 import { trimBaseURL } from './util.js'
 
@@ -34,9 +34,7 @@ export const remarkImageSalt: Plugin = function remarkImageSalt({
       inKeepBaseURL !== undefined ? inKeepBaseURL : defaultOpts.keepBaseURL,
     baseAttrs: inBaseAttrs !== undefined ? inBaseAttrs : defaultOpts.baseAttrs
   }
-  const { properties: baseProperties = {} } = baseAttrs
-    ? attrs(`#${baseAttrs}#`)
-    : { properties: {} }
+  const baseProperties = baseAttrs ? decodeAttrs(`${baseAttrs}`) : {}
 
   return function transformer(tree: Node): void {
     visitParents(tree, 'image', (node, parents) => {
@@ -51,7 +49,7 @@ export const remarkImageSalt: Plugin = function remarkImageSalt({
         Object.assign(workProperties, baseProperties, ex.properties || {})
         const properties: Properties = {}
         Object.assign(properties)
-        Object.entries(workProperties || {}).forEach(([k, v]) => {
+        Object.entries(workProperties).forEach(([k, v]) => {
           let key = k
           let value = v
           let set = true

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -12,18 +12,26 @@ export type RemarkImageSaltOptions = {
   tagName?: string
   baseURL?: string
   keepBaseURL?: boolean
+  baseAttrs?: string
 }
 const defaultOpts: Required<RemarkImageSaltOptions> = {
   tagName: 'img',
   baseURL: '',
-  keepBaseURL: false
+  keepBaseURL: false,
+  baseAttrs: ''
 }
 
 export const remarkImageSalt: Plugin = function remarkImageSalt({
   tagName,
   baseURL,
-  keepBaseURL
+  keepBaseURL,
+  baseAttrs
 }: RemarkImageSaltOptions = defaultOpts): Transformer {
+  const baseAttrStr = baseAttrs || defaultOpts.baseAttrs
+  const { properties: baseProperties = {} } = baseAttrStr
+    ? attrs(`#${baseAttrStr}#`)
+    : { properties: {} }
+
   return function transformer(tree: Node): void {
     visitParents(tree, 'image', (node, parents) => {
       const parent: Parent = parents[parents.length - 1]
@@ -33,8 +41,11 @@ export const remarkImageSalt: Plugin = function remarkImageSalt({
       if (image.url.startsWith(baseURL || defaultOpts.baseURL)) {
         let url = image.url
         const ex = image.alt ? attrs(image.alt) : { alt: '' }
+        const workProperties: Properties = {}
+        Object.assign(workProperties, baseProperties, ex.properties || {})
         const properties: Properties = {}
-        Object.entries(ex.properties || {}).forEach(([k, v]) => {
+        Object.assign(properties)
+        Object.entries(workProperties || {}).forEach(([k, v]) => {
           let key = k
           let value = v
           let set = true

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -50,7 +50,7 @@ export const remarkImageSalt: Plugin = function remarkImageSalt({
         const workProperties: Properties = {}
         Object.assign(workProperties, baseProperties, ex.properties || {})
         const properties: Properties = {}
-        Object.assign(properties)
+
         Object.entries(workProperties).forEach(([k, v]) => {
           let key = k
           let value = v

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -1,0 +1,38 @@
+import { Plugin, Transformer } from 'unified'
+import { Node } from 'unist'
+import { Parent, Image, HTML } from 'mdast'
+import { Element } from 'hast'
+import { visitParents } from 'unist-util-visit-parents'
+import { toHtml } from 'hast-util-to-html'
+
+export type RemarkImageSaltOptions = {
+  tagName?: string
+}
+const defaultTagName = 'img'
+
+export const remarkImageSalt: Plugin = function remarkImageSalt(
+  { tagName }: RemarkImageSaltOptions = { tagName: defaultTagName }
+): Transformer {
+  return function transformer(tree: Node): void {
+    visitParents(tree, 'image', (node, parents) => {
+      const parent: Parent = parents[parents.length - 1]
+      const imageIdx = parent.children.findIndex((n) => n === node)
+      const image: Image = node
+
+      const htmlTag: Element = {
+        type: 'element',
+        tagName: tagName || defaultTagName,
+        properties: {
+          src: image.url,
+          title: image.title
+        },
+        children: []
+      }
+      const htmlNode: HTML = {
+        type: 'html',
+        value: toHtml(htmlTag)
+      }
+      parent.children[imageIdx] = htmlNode
+    })
+  }
+}

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -1,10 +1,11 @@
 import { Plugin, Transformer } from 'unified'
 import { Node } from 'unist'
 import { Parent, Image, HTML } from 'mdast'
-import { Element } from 'hast'
+import { Element, Properties } from 'hast'
 import { visitParents } from 'unist-util-visit-parents'
 import { toHtml } from 'hast-util-to-html'
 import { attrs } from './alt-attrs.js'
+import { toModifiers } from './query.js'
 
 export type RemarkImageSaltOptions = {
   tagName?: string
@@ -21,6 +22,16 @@ export const remarkImageSalt: Plugin = function remarkImageSalt(
       const image: Image = node
 
       const ex = image.alt ? attrs(image.alt) : { alt: '' }
+      const properties: Properties = {}
+      Object.entries(ex.properties || {}).forEach(([k, v]) => {
+        let key = k
+        let value = v
+        if (k === 'modifiers') {
+          key = `:${k}`
+          value = JSON.stringify(toModifiers(`${v}`))
+        }
+        properties[key] = value
+      })
       const htmlTag: Element = {
         type: 'element',
         tagName: tagName || defaultTagName,
@@ -28,7 +39,7 @@ export const remarkImageSalt: Plugin = function remarkImageSalt(
           src: image.url,
           title: image.title,
           alt: ex.alt,
-          ...ex.properties
+          ...properties
         },
         children: []
       }

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -4,6 +4,7 @@ import { Parent, Image, HTML } from 'mdast'
 import { Element } from 'hast'
 import { visitParents } from 'unist-util-visit-parents'
 import { toHtml } from 'hast-util-to-html'
+import { attrs } from './alt-attrs.js'
 
 export type RemarkImageSaltOptions = {
   tagName?: string
@@ -19,12 +20,15 @@ export const remarkImageSalt: Plugin = function remarkImageSalt(
       const imageIdx = parent.children.findIndex((n) => n === node)
       const image: Image = node
 
+      const ex = image.alt ? attrs(image.alt) : { alt: '' }
       const htmlTag: Element = {
         type: 'element',
         tagName: tagName || defaultTagName,
         properties: {
           src: image.url,
-          title: image.title
+          title: image.title,
+          alt: ex.alt,
+          ...ex.properties
         },
         children: []
       }

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -22,14 +22,16 @@ const defaultOpts: Required<RemarkImageSaltOptions> = {
 }
 
 export const remarkImageSalt: Plugin = function remarkImageSalt({
-  tagName,
-  baseURL,
+  tagName: inTagName,
+  baseURL: inBaseURL,
   keepBaseURL,
-  baseAttrs
+  baseAttrs: inBaseAttrs
 }: RemarkImageSaltOptions = defaultOpts): Transformer {
-  const baseAttrStr = baseAttrs || defaultOpts.baseAttrs
-  const { properties: baseProperties = {} } = baseAttrStr
-    ? attrs(`#${baseAttrStr}#`)
+  const tagName = inTagName || defaultOpts.tagName
+  const baseURL = inBaseURL || defaultOpts.baseURL
+  const baseAttr = inBaseAttrs || defaultOpts.baseAttrs
+  const { properties: baseProperties = {} } = baseAttr
+    ? attrs(`#${baseAttr}#`)
     : { properties: {} }
 
   return function transformer(tree: Node): void {
@@ -38,7 +40,7 @@ export const remarkImageSalt: Plugin = function remarkImageSalt({
       const imageIdx = parent.children.findIndex((n) => n === node)
       const image: Image = node
 
-      if (image.url.startsWith(baseURL || defaultOpts.baseURL)) {
+      if (image.url.startsWith(baseURL)) {
         let url = image.url
         const ex = image.alt ? attrs(image.alt) : { alt: '' }
         const workProperties: Properties = {}
@@ -53,10 +55,10 @@ export const remarkImageSalt: Plugin = function remarkImageSalt({
             key = `:${k}`
             value = JSON.stringify(toModifiers(`${v}`))
           } else if (k === 'qq') {
-            url = editQuery('', url, `${v}`, true) // start は baseURL 的なものを設定したときに.
+            url = editQuery(baseURL, url, `${v}`, true)
             set = false
           } else if (k === 'q') {
-            url = editQuery('', url, `${v}`, false)
+            url = editQuery(baseURL, url, `${v}`, false)
             set = false
           }
           if (set) {
@@ -68,7 +70,7 @@ export const remarkImageSalt: Plugin = function remarkImageSalt({
         }
         const htmlTag: Element = {
           type: 'element',
-          tagName: tagName || defaultOpts.tagName,
+          tagName,
           properties: {
             src: url,
             title: image.title,

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -24,14 +24,18 @@ const defaultOpts: Required<RemarkImageSaltOptions> = {
 export const remarkImageSalt: Plugin = function remarkImageSalt({
   tagName: inTagName,
   baseURL: inBaseURL,
-  keepBaseURL,
+  keepBaseURL: inKeepBaseURL,
   baseAttrs: inBaseAttrs
 }: RemarkImageSaltOptions = defaultOpts): Transformer {
-  const tagName = inTagName || defaultOpts.tagName
-  const baseURL = inBaseURL || defaultOpts.baseURL
-  const baseAttr = inBaseAttrs || defaultOpts.baseAttrs
-  const { properties: baseProperties = {} } = baseAttr
-    ? attrs(`#${baseAttr}#`)
+  const { tagName, baseURL, keepBaseURL, baseAttrs }: typeof defaultOpts = {
+    tagName: inTagName !== undefined ? inTagName : defaultOpts.tagName,
+    baseURL: inBaseURL !== undefined ? inBaseURL : defaultOpts.baseURL,
+    keepBaseURL:
+      inKeepBaseURL !== undefined ? inKeepBaseURL : defaultOpts.keepBaseURL,
+    baseAttrs: inBaseAttrs !== undefined ? inBaseAttrs : defaultOpts.baseAttrs
+  }
+  const { properties: baseProperties = {} } = baseAttrs
+    ? attrs(`#${baseAttrs}#`)
     : { properties: {} }
 
   return function transformer(tree: Node): void {

--- a/src/image-salt.ts
+++ b/src/image-salt.ts
@@ -6,58 +6,72 @@ import { visitParents } from 'unist-util-visit-parents'
 import { toHtml } from 'hast-util-to-html'
 import { attrs } from './alt-attrs.js'
 import { editQuery, toModifiers } from './query.js'
+import { trimBaseURL } from './util.js'
 
 export type RemarkImageSaltOptions = {
   tagName?: string
+  baseURL?: string
+  keepBaseURL?: boolean
 }
-const defaultTagName = 'img'
+const defaultOpts: Required<RemarkImageSaltOptions> = {
+  tagName: 'img',
+  baseURL: '',
+  keepBaseURL: false
+}
 
-export const remarkImageSalt: Plugin = function remarkImageSalt(
-  { tagName }: RemarkImageSaltOptions = { tagName: defaultTagName }
-): Transformer {
+export const remarkImageSalt: Plugin = function remarkImageSalt({
+  tagName,
+  baseURL,
+  keepBaseURL
+}: RemarkImageSaltOptions = defaultOpts): Transformer {
   return function transformer(tree: Node): void {
     visitParents(tree, 'image', (node, parents) => {
       const parent: Parent = parents[parents.length - 1]
       const imageIdx = parent.children.findIndex((n) => n === node)
       const image: Image = node
 
-      let url = image.url
-      const ex = image.alt ? attrs(image.alt) : { alt: '' }
-      const properties: Properties = {}
-      Object.entries(ex.properties || {}).forEach(([k, v]) => {
-        let key = k
-        let value = v
-        let set = true
-        if (k === 'modifiers') {
-          key = `:${k}`
-          value = JSON.stringify(toModifiers(`${v}`))
-        } else if (k === 'qq') {
-          url = editQuery('', url, `${v}`, true) // start は baseURL 的なものを設定したときに.
-          set = false
-        } else if (k === 'q') {
-          url = editQuery('', url, `${v}`, false)
-          set = false
+      if (image.url.startsWith(baseURL || defaultOpts.baseURL)) {
+        let url = image.url
+        const ex = image.alt ? attrs(image.alt) : { alt: '' }
+        const properties: Properties = {}
+        Object.entries(ex.properties || {}).forEach(([k, v]) => {
+          let key = k
+          let value = v
+          let set = true
+          if (k === 'modifiers') {
+            key = `:${k}`
+            value = JSON.stringify(toModifiers(`${v}`))
+          } else if (k === 'qq') {
+            url = editQuery('', url, `${v}`, true) // start は baseURL 的なものを設定したときに.
+            set = false
+          } else if (k === 'q') {
+            url = editQuery('', url, `${v}`, false)
+            set = false
+          }
+          if (set) {
+            properties[key] = value
+          }
+        })
+        if (!keepBaseURL) {
+          url = trimBaseURL(baseURL, url)
         }
-        if (set) {
-          properties[key] = value
+        const htmlTag: Element = {
+          type: 'element',
+          tagName: tagName || defaultOpts.tagName,
+          properties: {
+            src: url,
+            title: image.title,
+            alt: ex.alt,
+            ...properties
+          },
+          children: []
         }
-      })
-      const htmlTag: Element = {
-        type: 'element',
-        tagName: tagName || defaultTagName,
-        properties: {
-          src: url,
-          title: image.title,
-          alt: ex.alt,
-          ...properties
-        },
-        children: []
+        const htmlNode: HTML = {
+          type: 'html',
+          value: toHtml(htmlTag)
+        }
+        parent.children[imageIdx] = htmlNode
       }
-      const htmlNode: HTML = {
-        type: 'html',
-        value: toHtml(htmlTag)
-      }
-      parent.children[imageIdx] = htmlNode
     })
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,10 +38,10 @@ import cli from './cli.js'
       stdin: process.stdin,
       stdout: process.stdout,
       stderr: process.stderr,
-      tagName: argv['tag-name'] || '',
-      baseURL: argv['base-url'] || '',
-      keepBaseURL: argv['keep-base-url'] || false,
-      baseAttrs: argv['base-attrs'] || ''
+      tagName: argv['tag-name'],
+      baseURL: argv['base-url'],
+      keepBaseURL: argv['keep-base-url'],
+      baseAttrs: argv['base-attrs']
     })
   )
 })()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { basename } from 'path/posix'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import cli from './cli.js'
@@ -13,6 +14,16 @@ import cli from './cli.js'
         type: 'string',
         required: false,
         description: 'a Tag name to use generated tag'
+      },
+      'base-url': {
+        type: 'string',
+        required: false,
+        description: 'select image node'
+      },
+      'keep-base-url': {
+        type: 'boolean',
+        required: false,
+        description: 'keep baseURL in src of image'
       }
     })
     .help().argv
@@ -22,7 +33,9 @@ import cli from './cli.js'
       stdin: process.stdin,
       stdout: process.stdout,
       stderr: process.stderr,
-      tagName:argv['tag-name']||''
+      tagName: argv['tag-name'] || '',
+      baseURL: argv['base-url'] || '',
+      keepBaseURL: argv['keep-base-url'] || false
     })
   )
 })()

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,20 +2,27 @@
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import cli from './cli.js'
-
 ;(async () => {
   const argv = await yargs(hideBin(process.argv))
-    .scriptName('count')
-    .usage('$0 [FILE]...')
-    .example('$0 foo.ts bar.ts', 'count chars in files')
-    .demand(1)
+    .scriptName('image-salt')
+    .env('IMAGE_SALT')
+    .usage('$0 [OPTION]... --')
+    .example('cat foo.md | $0', 'generate img tag by Image node in markdown')
+    .options({
+      'tag-name': {
+        type: 'string',
+        required: false,
+        description: 'a Tag name to use generated tag'
+      }
+    })
     .help().argv
 
   process.exit(
     await cli({
-      filenames: argv._ as string[],
+      stdin: process.stdin,
       stdout: process.stdout,
-      stderr: process.stderr
+      stderr: process.stderr,
+      tagName:argv['tag-name']||''
     })
   )
 })()

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,11 @@ import cli from './cli.js'
         type: 'boolean',
         required: false,
         description: 'keep baseURL in src of image'
+      },
+      'base-attrs': {
+        type: 'string',
+        required: false,
+        description: 'base attrs to set tag generated'
       }
     })
     .help().argv
@@ -35,7 +40,8 @@ import cli from './cli.js'
       stderr: process.stderr,
       tagName: argv['tag-name'] || '',
       baseURL: argv['base-url'] || '',
-      keepBaseURL: argv['keep-base-url'] || false
+      keepBaseURL: argv['keep-base-url'] || false,
+      baseAttrs: argv['base-attrs'] || ''
     })
   )
 })()

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,0 +1,47 @@
+// image-url-workbench からコピー
+//-- ここから
+const regExpPlus = /\+/g
+const regExpSlash = /\//g
+const regExpTrailEq = /=+$/g
+
+const regExpHyphen = /-/g
+const regExpLowDash = /_/g
+
+export function encodeBase64Url(v: string): string {
+  // https://docs.imgix.com/apis/rendering#base64-variants
+  // https://developer.mozilla.org/ja/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
+  // https://stackoverflow.com/questions/24523532/how-do-i-convert-an-image-to-a-base64-encoded-data-url-in-sails-js-or-generally
+  // https://qiita.com/awakia/items/049791daca69120d7035
+  return Buffer.from(`${v}`, 'utf-8')
+    .toString('base64')
+    .replace(regExpSlash, '_')
+    .replace(regExpPlus, '-')
+    .replace(regExpTrailEq, '')
+}
+
+export function decodeBase64Url(v: string): string {
+  // 末尾の = は足さなくてもエラー等にはならないもよう
+  return Buffer.from(
+    v.replace(regExpHyphen, '+').replace(regExpLowDash, '/'),
+    'base64'
+  ).toString()
+}
+//-- ここまで
+
+const b64variantRegExp = /^(.+)64$/
+export function toModifiers(query: string): Record<string, any> {
+  const ret: Record<string, any> = {}
+  const q = new URLSearchParams(query)
+  q.forEach((v, k) => {
+    let key = k
+    let value = v
+    // nuxt-image では Base64 Variants が扱われないようなので(fit64 がパススルー状態になる)戻す.
+    const m = k.match(b64variantRegExp)
+    if (m) {
+      key = m[1]
+      value = decodeBase64Url(v)
+    }
+    ret[key] = value
+  })
+  return ret
+}

--- a/src/query.ts
+++ b/src/query.ts
@@ -28,6 +28,32 @@ export function decodeBase64Url(v: string): string {
 }
 //-- ここまで
 
+export function editQuery(
+  start: string,
+  url: string,
+  params: string,
+  replace?: boolean
+): string {
+  if (url.startsWith(start)) {
+    const u = url.split('?', 2)
+    const srcQ = new URLSearchParams(replace ? '' : u[1] || '')
+    const q = new URLSearchParams(params)
+    q.forEach((v, k) => {
+      if (srcQ.has(k)) {
+        srcQ.set(k, v)
+      } else {
+        srcQ.append(k, v)
+      }
+    })
+    const p = srcQ.toString()
+    if (p) {
+      return `${u[0]}?${p}`
+    }
+    return u[0]
+  }
+  return url
+}
+
 const b64variantRegExp = /^(.+)64$/
 export function toModifiers(query: string): Record<string, any> {
   const ret: Record<string, any> = {}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,10 @@
+export function trimBaseURL(base: string | undefined, url: string): string {
+  if (base && url.startsWith(base)) {
+    const t = url.substring(base.length)
+    if (!t.startsWith('/')) {
+      return `/${t}`
+    }
+    return t
+  }
+  return url
+}

--- a/test/__snapshots__/cli.spec.ts.snap
+++ b/test/__snapshots__/cli.spec.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cli() should apply baseAttrs 1`] = `
+"# test
+
+## test1
+
+image-salt-1
+
+<img src=\\"https://localhost:3000/path/to/iamge1.jpg\\" alt=\\"image1\\" provider=\\"imgix\\" class=\\"light-img\\">
+
+## test2
+
+image-salt-2
+
+![image2](https://localhost:3001/path/to/iamge2.jpg)
+"
+`;
+
 exports[`cli() should keep baseURL 1`] = `
 "# test
 

--- a/test/__snapshots__/cli.spec.ts.snap
+++ b/test/__snapshots__/cli.spec.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cli() should keep baseURL 1`] = `
+"# test
+
+## test1
+
+image-salt-1
+
+<img src=\\"https://localhost:3000/path/to/iamge1.jpg\\" alt=\\"image1\\">
+
+## test2
+
+image-salt-2
+
+![image2](https://localhost:3001/path/to/iamge2.jpg)
+"
+`;
+
 exports[`cli() should return stderr with exitcode=1 1`] = `
 "Error: extractAttrs: invalid attrs has injected
 "
@@ -19,5 +36,22 @@ image-salt-1
 image-salt-2
 
 <img src=\\"/path/to/iamge2.jpg\\" alt=\\"image2\\">
+"
+`;
+
+exports[`cli() should skip url was not matched baseURL 1`] = `
+"# test
+
+## test1
+
+image-salt-1
+
+<img src=\\"/path/to/iamge1.jpg\\" alt=\\"image1\\">
+
+## test2
+
+image-salt-2
+
+![image2](https://localhost:3001/path/to/iamge2.jpg)
 "
 `;

--- a/test/__snapshots__/cli.spec.ts.snap
+++ b/test/__snapshots__/cli.spec.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cli() should return stderr with exitcode=1 1`] = `
+"Error: extractAttrs: invalid attrs has injected
+"
+`;
+
 exports[`cli() should return stdout with exitcode=0 1`] = `
 "# test
 
@@ -7,12 +12,12 @@ exports[`cli() should return stdout with exitcode=0 1`] = `
 
 image-salt-1
 
-<img src=\\"/path/to/iamge1.jpg\\">
+<img src=\\"/path/to/iamge1.jpg\\" alt=\\"image1\\">
 
 ## test2
 
 image-salt-2
 
-<img src=\\"/path/to/iamge2.jpg\\">
+<img src=\\"/path/to/iamge2.jpg\\" alt=\\"image2\\">
 "
 `;

--- a/test/__snapshots__/cli.spec.ts.snap
+++ b/test/__snapshots__/cli.spec.ts.snap
@@ -7,13 +7,13 @@ exports[`cli() should apply baseAttrs 1`] = `
 
 image-salt-1
 
-<img src=\\"https://localhost:3000/path/to/iamge1.jpg\\" alt=\\"image1\\" provider=\\"imgix\\" class=\\"light-img\\">
+<img src=\\"https://localhost:3000/path/to/image1.jpg\\" alt=\\"image1\\" provider=\\"imgix\\" class=\\"light-img\\">
 
 ## test2
 
 image-salt-2
 
-![image2](https://localhost:3001/path/to/iamge2.jpg)
+![image2](https://localhost:3001/path/to/image2.jpg)
 "
 `;
 
@@ -24,13 +24,13 @@ exports[`cli() should keep baseURL 1`] = `
 
 image-salt-1
 
-<img src=\\"https://localhost:3000/path/to/iamge1.jpg\\" alt=\\"image1\\">
+<img src=\\"https://localhost:3000/path/to/image1.jpg\\" alt=\\"image1\\">
 
 ## test2
 
 image-salt-2
 
-![image2](https://localhost:3001/path/to/iamge2.jpg)
+![image2](https://localhost:3001/path/to/image2.jpg)
 "
 `;
 
@@ -46,13 +46,13 @@ exports[`cli() should return stdout with exitcode=0 1`] = `
 
 image-salt-1
 
-<img src=\\"/path/to/iamge1.jpg\\" alt=\\"image1\\">
+<img src=\\"/path/to/image1.jpg\\" alt=\\"image1\\">
 
 ## test2
 
 image-salt-2
 
-<img src=\\"/path/to/iamge2.jpg\\" alt=\\"image2\\">
+<img src=\\"/path/to/image2.jpg\\" alt=\\"image2\\">
 "
 `;
 
@@ -63,12 +63,12 @@ exports[`cli() should skip url was not matched baseURL 1`] = `
 
 image-salt-1
 
-<img src=\\"/path/to/iamge1.jpg\\" alt=\\"image1\\">
+<img src=\\"/path/to/image1.jpg\\" alt=\\"image1\\">
 
 ## test2
 
 image-salt-2
 
-![image2](https://localhost:3001/path/to/iamge2.jpg)
+![image2](https://localhost:3001/path/to/image2.jpg)
 "
 `;

--- a/test/__snapshots__/cli.spec.ts.snap
+++ b/test/__snapshots__/cli.spec.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cli() should return stdout with exitcode=0 1`] = `
+"# test
+
+## test1
+
+image-salt-1
+
+<img src=\\"/path/to/iamge1.jpg\\">
+
+## test2
+
+image-salt-2
+
+<img src=\\"/path/to/iamge2.jpg\\">
+"
+`;

--- a/test/alt-attrs.spec.ts
+++ b/test/alt-attrs.spec.ts
@@ -1,0 +1,84 @@
+import { attrs } from '../src/alt-attrs'
+
+describe('alt-attr', () => {
+  it('should extract attrs', async () => {
+    expect(
+      attrs('abc#class="light-img" sizes="sm:100vw md:50vw lg:400px"#')
+    ).toEqual({
+      alt: 'abc',
+      properties: {
+        className: ['light-img'],
+        sizes: 'sm:100vw md:50vw lg:400px'
+      }
+    })
+    expect(
+      attrs('#class="light-img" sizes="sm:100vw md:50vw lg:400px"#ABC')
+    ).toEqual({
+      alt: 'ABC',
+      properties: {
+        className: ['light-img'],
+        sizes: 'sm:100vw md:50vw lg:400px'
+      }
+    })
+    expect(
+      attrs('abc#class="light-img" sizes="sm:100vw md:50vw lg:400px"#ABC')
+    ).toEqual({
+      alt: 'abcABC',
+      properties: {
+        className: ['light-img'],
+        sizes: 'sm:100vw md:50vw lg:400px'
+      }
+    })
+  })
+  it('should extract attrs with dimension', async () => {
+    expect(
+      attrs(
+        'abc#d:300x200 class="light-img" sizes="sm:100vw md:50vw lg:400px"#'
+      )
+    ).toEqual({
+      alt: 'abc',
+      properties: {
+        width: 300,
+        height: 200,
+        className: ['light-img'],
+        sizes: 'sm:100vw md:50vw lg:400px'
+      }
+    })
+  })
+  it('should extract attrs as enpty', async () => {
+    expect(attrs('abc# #')).toEqual({
+      alt: 'abc',
+      properties: {}
+    })
+  })
+  it('should extract attrs with query', async () => {
+    expect(
+      attrs(
+        'abc#d:300x200 class="light-img" q="auto=compress%2Cformat&crop64=Zm9jYWxwb2ludA&fit64=Y3JvcA&fp-x64=MC42&fp-z64=MS4z" sizes="sm:100vw md:50vw lg:400px"#'
+      )
+    ).toEqual({
+      alt: 'abc',
+      properties: {
+        width: 300,
+        height: 200,
+        q: 'auto=compress%2Cformat&crop64=Zm9jYWxwb2ludA&fit64=Y3JvcA&fp-x64=MC42&fp-z64=MS4z',
+        className: ['light-img'],
+        sizes: 'sm:100vw md:50vw lg:400px'
+      }
+    })
+  })
+  it('should return just alt', async () => {
+    expect(attrs('abc')).toEqual({ alt: 'abc' })
+    expect(attrs('abc#')).toEqual({ alt: 'abc#' })
+    expect(attrs('abc##')).toEqual({ alt: 'abc##' })
+    expect(attrs('abc#ABC')).toEqual({ alt: 'abc#ABC' })
+    expect(attrs('abc##ABC')).toEqual({ alt: 'abc##ABC' })
+  })
+  it('should trhow error when invalid attrs has injected', async () => {
+    expect(() =>
+      attrs(
+        'abc#d:300x200 class="light-img" sizes="sm:100vw md:50vw lg:400px" >#'
+      )
+    ).toThrowError('extractAttrs: invalid attrs has injected')
+  })
+})

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -1,11 +1,18 @@
+import { ReadStream } from 'fs'
 import { PassThrough } from 'stream'
 import cli from '../src/cli.js'
 
 describe('cli()', () => {
+  let stdin: PassThrough
+  let stdout: PassThrough
+  let stderr: PassThrough
+  beforeEach(() => {
+    stdin = new PassThrough()
+    stdout = new PassThrough()
+    stderr = new PassThrough()
+  })
+
   it('should return stdout with exitcode=0', async () => {
-    const stdin = new PassThrough()
-    const stdout = new PassThrough()
-    const stderr = new PassThrough()
     let outData = ''
     stdout.on('data', (d) => (outData = outData + d))
     let errData = ''
@@ -22,16 +29,65 @@ describe('cli()', () => {
         stdin,
         stdout,
         stderr,
-        tagName: ''
+        tagName: '',
+        baseURL: '',
+        keepBaseURL: false
+      })
+    ).toEqual(0)
+    expect(outData).toMatchSnapshot()
+    expect(errData).toEqual('')
+  })
+  it('should skip url was not matched baseURL', async () => {
+    let outData = ''
+    stdout.on('data', (d) => (outData = outData + d))
+    let errData = ''
+    stderr.on('data', (d) => (errData = errData + d))
+    process.nextTick(() => {
+      stdin.write(
+        '# test\n## test1\nimage-salt-1\n\n![image1](https://localhost:3000/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](https://localhost:3001/path/to/iamge2.jpg)'
+      )
+      stdin.end()
+    })
+
+    expect(
+      await cli({
+        stdin,
+        stdout,
+        stderr,
+        tagName: '',
+        baseURL: 'https://localhost:3000/',
+        keepBaseURL: false
+      })
+    ).toEqual(0)
+    expect(outData).toMatchSnapshot()
+    expect(errData).toEqual('')
+  })
+  it('should keep baseURL', async () => {
+    let outData = ''
+    stdout.on('data', (d) => (outData = outData + d))
+    let errData = ''
+    stderr.on('data', (d) => (errData = errData + d))
+    process.nextTick(() => {
+      stdin.write(
+        '# test\n## test1\nimage-salt-1\n\n![image1](https://localhost:3000/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](https://localhost:3001/path/to/iamge2.jpg)'
+      )
+      stdin.end()
+    })
+
+    expect(
+      await cli({
+        stdin,
+        stdout,
+        stderr,
+        tagName: '',
+        baseURL: 'https://localhost:3000/',
+        keepBaseURL: true
       })
     ).toEqual(0)
     expect(outData).toMatchSnapshot()
     expect(errData).toEqual('')
   })
   it('should return stderr with exitcode=1', async () => {
-    const stdin = new PassThrough()
-    const stdout = new PassThrough()
-    const stderr = new PassThrough()
     let outData = ''
     stdout.on('data', (d) => (outData = outData + d))
     let errData = ''
@@ -48,7 +104,9 @@ describe('cli()', () => {
         stdin,
         stdout,
         stderr,
-        tagName: ''
+        tagName: '',
+        baseURL: '',
+        keepBaseURL: false
       })
     ).toEqual(1)
     expect(outData).toEqual('')

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -1,53 +1,31 @@
-import { jest } from '@jest/globals'
 import { PassThrough } from 'stream'
 import cli from '../src/cli'
 
 describe('cli()', () => {
   it('should return stdout with exitcode=0', async () => {
+    const stdin = new PassThrough()
     const stdout = new PassThrough()
     const stderr = new PassThrough()
-    const outData = jest.fn()
-    stdout.on('data', outData)
-    const errData = jest.fn()
-    stderr.on('data', errData)
+    let outData = ''
+    stdout.on('data', (d) => (outData = outData + d))
+    let errData = ''
+    stderr.on('data', (d) => (errData = errData + d))
+    process.nextTick(() => {
+      stdin.write(
+        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](/path/to/iamge2.jpg)'
+      )
+      stdin.end()
+    })
+
     expect(
       await cli({
-        filenames: ['test/assets/test1.txt', 'test/assets/test2.txt'],
+        stdin,
         stdout,
-        stderr
+        stderr,
+        tagName: ''
       })
     ).toEqual(0)
-    expect(outData.mock.calls.length).toEqual(2)
-    expect((outData.mock.calls[0][0] as Buffer).toString('utf8')).toEqual(
-      'test/assets/test1.txt: 15 chars\n'
-    )
-    expect((outData.mock.calls[1][0] as Buffer).toString('utf8')).toEqual(
-      'test/assets/test2.txt: 17 chars\n'
-    )
-    expect(errData.mock.calls.length).toEqual(0)
-  })
-  it('should return stderr with exitcode=1', async () => {
-    const stdout = new PassThrough()
-    const stderr = new PassThrough()
-    const outData = jest.fn()
-    stdout.on('data', outData)
-    const errData = jest.fn()
-    stderr.on('data', errData)
-    expect(
-      await cli({
-        filenames: ['test/assets/test1.txt', 'test/assets/fail.txt'],
-        stdout,
-        stderr
-      })
-    ).toEqual(1)
-    expect(outData.mock.calls.length).toEqual(1)
-    expect((outData.mock.calls[0][0] as Buffer).toString('utf8')).toEqual(
-      'test/assets/test1.txt: 15 chars\n'
-    )
-    expect(errData.mock.calls.length).toEqual(2)
-    expect((errData.mock.calls[0][0] as Buffer).toString('utf8')).toEqual(
-      "Error: ENOENT: no such file or directory, open 'test/assets/fail.txt'"
-    )
-    expect((errData.mock.calls[1][0] as Buffer).toString('utf8')).toEqual('\n')
+    expect(outData).toMatchSnapshot()
+    expect(errData).toEqual('')
   })
 })

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -21,7 +21,7 @@ describe('cli()', () => {
     io.stderr.on('data', (d) => (errData = errData + d))
     process.nextTick(() => {
       io.stdin.write(
-        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](/path/to/iamge2.jpg)'
+        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/image1.jpg)\n## test2\nimage-salt-2\n\n![image2](/path/to/image2.jpg)'
       )
       io.stdin.end()
     })
@@ -41,7 +41,7 @@ describe('cli()', () => {
     io.stderr.on('data', (d) => (errData = errData + d))
     process.nextTick(() => {
       io.stdin.write(
-        '# test\n## test1\nimage-salt-1\n\n![image1](https://localhost:3000/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](https://localhost:3001/path/to/iamge2.jpg)'
+        '# test\n## test1\nimage-salt-1\n\n![image1](https://localhost:3000/path/to/image1.jpg)\n## test2\nimage-salt-2\n\n![image2](https://localhost:3001/path/to/image2.jpg)'
       )
       io.stdin.end()
     })
@@ -62,7 +62,7 @@ describe('cli()', () => {
     io.stderr.on('data', (d) => (errData = errData + d))
     process.nextTick(() => {
       io.stdin.write(
-        '# test\n## test1\nimage-salt-1\n\n![image1](https://localhost:3000/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](https://localhost:3001/path/to/iamge2.jpg)'
+        '# test\n## test1\nimage-salt-1\n\n![image1](https://localhost:3000/path/to/image1.jpg)\n## test2\nimage-salt-2\n\n![image2](https://localhost:3001/path/to/image2.jpg)'
       )
       io.stdin.end()
     })
@@ -84,7 +84,7 @@ describe('cli()', () => {
     io.stderr.on('data', (d) => (errData = errData + d))
     process.nextTick(() => {
       io.stdin.write(
-        '# test\n## test1\nimage-salt-1\n\n![image1](https://localhost:3000/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](https://localhost:3001/path/to/iamge2.jpg)'
+        '# test\n## test1\nimage-salt-1\n\n![image1](https://localhost:3000/path/to/image1.jpg)\n## test2\nimage-salt-2\n\n![image2](https://localhost:3001/path/to/image2.jpg)'
       )
       io.stdin.end()
     })
@@ -107,7 +107,7 @@ describe('cli()', () => {
     io.stderr.on('data', (d) => (errData = errData + d))
     process.nextTick(() => {
       io.stdin.write(
-        '# test\n## test1\nimage-salt-1\n\n![image1#d300x200>#](/path/to/iamge1.jpg)'
+        '# test\n## test1\nimage-salt-1\n\n![image1#d300x200>#](/path/to/image1.jpg)'
       )
       io.stdin.end()
     })

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -1,5 +1,5 @@
 import { PassThrough } from 'stream'
-import cli from '../src/cli'
+import cli from '../src/cli.js'
 
 describe('cli()', () => {
   it('should return stdout with exitcode=0', async () => {
@@ -27,5 +27,31 @@ describe('cli()', () => {
     ).toEqual(0)
     expect(outData).toMatchSnapshot()
     expect(errData).toEqual('')
+  })
+  it('should return stderr with exitcode=1', async () => {
+    const stdin = new PassThrough()
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let outData = ''
+    stdout.on('data', (d) => (outData = outData + d))
+    let errData = ''
+    stderr.on('data', (d) => (errData = errData + d))
+    process.nextTick(() => {
+      stdin.write(
+        '# test\n## test1\nimage-salt-1\n\n![image1#d300x200>#](/path/to/iamge1.jpg)'
+      )
+      stdin.end()
+    })
+
+    expect(
+      await cli({
+        stdin,
+        stdout,
+        stderr,
+        tagName: ''
+      })
+    ).toEqual(1)
+    expect(outData).toEqual('')
+    expect(errData).toMatchSnapshot()
   })
 })

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -28,11 +28,7 @@ describe('cli()', () => {
 
     expect(
       await cli({
-        ...io,
-        tagName: '',
-        baseURL: '',
-        keepBaseURL: false,
-        baseAttrs: ''
+        ...io
       })
     ).toEqual(0)
     expect(outData).toMatchSnapshot()
@@ -53,10 +49,7 @@ describe('cli()', () => {
     expect(
       await cli({
         ...io,
-        tagName: '',
-        baseURL: 'https://localhost:3000/',
-        keepBaseURL: false,
-        baseAttrs: ''
+        baseURL: 'https://localhost:3000/'
       })
     ).toEqual(0)
     expect(outData).toMatchSnapshot()
@@ -77,10 +70,8 @@ describe('cli()', () => {
     expect(
       await cli({
         ...io,
-        tagName: '',
         baseURL: 'https://localhost:3000/',
-        keepBaseURL: true,
-        baseAttrs: ''
+        keepBaseURL: true
       })
     ).toEqual(0)
     expect(outData).toMatchSnapshot()
@@ -101,7 +92,6 @@ describe('cli()', () => {
     expect(
       await cli({
         ...io,
-        tagName: '',
         baseURL: 'https://localhost:3000/',
         keepBaseURL: true,
         baseAttrs: 'provider="imgix" class="light-img"'

--- a/test/image-salt.spec.ts
+++ b/test/image-salt.spec.ts
@@ -24,23 +24,35 @@ describe('remarkImageSalt', () => {
       )
   }
 
+  // attrs がこの順番で出力されるとは限らない.
+  // 変化するようならユーティリティを利用.
   it('should generate img tag', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](/path/to/iamge2.jpg)'
+        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![](/path/to/iamge2.jpg)'
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg">\n\n## test2\n\nimage-salt-2\n\n<img src="/path/to/iamge2.jpg">\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg" alt="image1">\n\n## test2\n\nimage-salt-2\n\n<img src="/path/to/iamge2.jpg" alt="">\n'
     )
   })
-  it('should generate nux-img tag', async () => {
+  it('should generate nuxt-img tag', async () => {
     expect(
       await f(
         '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)',
         { tagName: 'nuxt-img' }
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg"></nuxt-img>\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1"></nuxt-img>\n'
+    )
+  })
+  it('should generate nuxt-img tag', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#d:300x200 class="light-img" sizes="sm:100vw md:50vw lg:400px"#](/path/to/iamge1.jpg)',
+        { tagName: 'nuxt-img' }
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" width="300" height="200" class="light-img" sizes="sm:100vw md:50vw lg:400px"></nuxt-img>\n'
     )
   })
 })

--- a/test/image-salt.spec.ts
+++ b/test/image-salt.spec.ts
@@ -29,111 +29,111 @@ describe('remarkImageSalt', () => {
   it('should generate img tag', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![](/path/to/iamge2.jpg)'
+        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/image1.jpg)\n## test2\nimage-salt-2\n\n![](/path/to/image2.jpg)'
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg" alt="image1">\n\n## test2\n\nimage-salt-2\n\n<img src="/path/to/iamge2.jpg" alt="">\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/image1.jpg" alt="image1">\n\n## test2\n\nimage-salt-2\n\n<img src="/path/to/image2.jpg" alt="">\n'
     )
   })
   it('should generate nuxt-img tag', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)',
+        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/image1.jpg)',
         { tagName: 'nuxt-img' }
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1"></nuxt-img>\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/image1.jpg" alt="image1"></nuxt-img>\n'
     )
   })
   it('should convert(decode) modifiers to :modifiers', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#modifiers="blur=100"#](/path/to/iamge1.jpg)',
+        '# test\n## test1\nimage-salt-1\n\n![image1#modifiers="blur=100"#](/path/to/image1.jpg)',
         { tagName: 'nuxt-img' }
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/image1.jpg" alt="image1" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
     )
   })
   it('should replace query parameter', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#qq="blur=100"#](/path/to/iamge1.jpg?w=300)'
+        '# test\n## test1\nimage-salt-1\n\n![image1#qq="blur=100"#](/path/to/image1.jpg?w=300)'
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg?blur=100" alt="image1">\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/image1.jpg?blur=100" alt="image1">\n'
     )
   })
   it('should merge query parameter', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](/path/to/iamge1.jpg?w=300&blur=200)'
+        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](/path/to/image1.jpg?w=300&blur=200)'
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg?w=300&#x26;blur=100" alt="image1">\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/image1.jpg?w=300&#x26;blur=100" alt="image1">\n'
     )
   })
   it('should skip url that was not matched baseURL', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3001/path/to/iamge1.jpg?w=300&blur=200)',
+        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3001/path/to/image1.jpg?w=300&blur=200)',
         {
           baseURL: 'https://localhost:3000/'
         }
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3001/path/to/iamge1.jpg?w=300\\&blur=200)\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3001/path/to/image1.jpg?w=300\\&blur=200)\n'
     )
   })
   it('should trim baseURL', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3000/path/to/iamge1.jpg?w=300&blur=200)',
+        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3000/path/to/image1.jpg?w=300&blur=200)',
         {
           baseURL: 'https://localhost:3000/'
         }
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg?w=300&#x26;blur=100" alt="image1">\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/image1.jpg?w=300&#x26;blur=100" alt="image1">\n'
     )
   })
   it('should keep baseURL', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3000/path/to/iamge1.jpg?w=300&blur=200)',
+        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3000/path/to/image1.jpg?w=300&blur=200)',
         {
           baseURL: 'https://localhost:3000',
           keepBaseURL: true
         }
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="https://localhost:3000/path/to/iamge1.jpg?w=300&#x26;blur=100" alt="image1">\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="https://localhost:3000/path/to/image1.jpg?w=300&#x26;blur=100" alt="image1">\n'
     )
   })
   it('should apply baseAttrs', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#modifiers="blur=100"#](/path/to/iamge1.jpg)',
+        '# test\n## test1\nimage-salt-1\n\n![image1#modifiers="blur=100"#](/path/to/image1.jpg)',
         {
           tagName: 'nuxt-img',
           baseAttrs: 'provider="imgix"'
         }
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" provider="imgix" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/image1.jpg" alt="image1" provider="imgix" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
     )
   })
   it('should overwrite baseAttrs', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#class="dark-img" modifiers="blur=100"#](/path/to/iamge1.jpg)',
+        '# test\n## test1\nimage-salt-1\n\n![image1#class="dark-img" modifiers="blur=100"#](/path/to/image1.jpg)',
         {
           tagName: 'nuxt-img',
           baseAttrs: 'provider="imgix" class="light-img"'
         }
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" provider="imgix" class="dark-img" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/image1.jpg" alt="image1" provider="imgix" class="dark-img" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
     )
   })
   it('should generate anchor tag', async () => {

--- a/test/image-salt.spec.ts
+++ b/test/image-salt.spec.ts
@@ -110,4 +110,30 @@ describe('remarkImageSalt', () => {
       '# test\n\n## test1\n\nimage-salt-1\n\n<img src="https://localhost:3000/path/to/iamge1.jpg?w=300&#x26;blur=100" alt="image1">\n'
     )
   })
+  it('should apply baseAttrs', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#modifiers="blur=100"#](/path/to/iamge1.jpg)',
+        {
+          tagName: 'nuxt-img',
+          baseAttrs: 'provider="imgix"'
+        }
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" provider="imgix" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
+    )
+  })
+  it('should overwrite baseAttrs', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#class="dark-img" modifiers="blur=100"#](/path/to/iamge1.jpg)',
+        {
+          tagName: 'nuxt-img',
+          baseAttrs: 'provider="imgix" class="light-img"'
+        }
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" provider="imgix" class="dark-img" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
+    )
+  })
 })

--- a/test/image-salt.spec.ts
+++ b/test/image-salt.spec.ts
@@ -1,0 +1,46 @@
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import stringify from 'remark-stringify'
+import { remarkImageSalt, RemarkImageSaltOptions } from '../src/image-salt.js'
+
+describe('remarkImageSalt', () => {
+  const f = async (
+    markdown: string,
+    opts?: RemarkImageSaltOptions
+  ): Promise<string> => {
+    return await unified()
+      .use(remarkParse)
+      .use(remarkImageSalt, opts)
+      .use(stringify)
+      .freeze()
+      .process(markdown)
+      .then(
+        (file) => {
+          return String(file)
+        },
+        (error) => {
+          throw error
+        }
+      )
+  }
+
+  it('should generate img tag', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)\n## test2\nimage-salt-2\n\n![image2](/path/to/iamge2.jpg)'
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg">\n\n## test2\n\nimage-salt-2\n\n<img src="/path/to/iamge2.jpg">\n'
+    )
+  })
+  it('should generate nux-img tag', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1](/path/to/iamge1.jpg)',
+        { tagName: 'nuxt-img' }
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg"></nuxt-img>\n'
+    )
+  })
+})

--- a/test/image-salt.spec.ts
+++ b/test/image-salt.spec.ts
@@ -136,4 +136,22 @@ describe('remarkImageSalt', () => {
       '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" provider="imgix" class="dark-img" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
     )
   })
+  it('should generate anchor tag', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#thumb#](/path/to/image1.jpg?w=300&h=200)'
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<a href="/path/to/image1.jpg" target="_blank" rel="noopener noreferrer"><img src="/path/to/image1.jpg?w=300&#x26;h=200" alt="image1"></a>\n'
+    )
+  })
+  it('should generate anchor tag(query)', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#thumb="w=600"#](/path/to/image1.jpg?w=300&h=200)'
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<a href="/path/to/image1.jpg?w=600" target="_blank" rel="noopener noreferrer"><img src="/path/to/image1.jpg?w=300&#x26;h=200" alt="image1"></a>\n'
+    )
+  })
 })

--- a/test/image-salt.spec.ts
+++ b/test/image-salt.spec.ts
@@ -45,6 +45,16 @@ describe('remarkImageSalt', () => {
       '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1"></nuxt-img>\n'
     )
   })
+  it('should convert(decode) modifiers to :modifiers', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#modifiers="blur=100"#](/path/to/iamge1.jpg)',
+        { tagName: 'nuxt-img' }
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
+    )
+  })
   it('should generate nuxt-img tag', async () => {
     expect(
       await f(

--- a/test/image-salt.spec.ts
+++ b/test/image-salt.spec.ts
@@ -73,4 +73,41 @@ describe('remarkImageSalt', () => {
       '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg?w=300&#x26;blur=100" alt="image1">\n'
     )
   })
+  it('should skip url that was not matched baseURL', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3001/path/to/iamge1.jpg?w=300&blur=200)',
+        {
+          baseURL: 'https://localhost:3000/'
+        }
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3001/path/to/iamge1.jpg?w=300\\&blur=200)\n'
+    )
+  })
+  it('should trim baseURL', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3000/path/to/iamge1.jpg?w=300&blur=200)',
+        {
+          baseURL: 'https://localhost:3000/'
+        }
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg?w=300&#x26;blur=100" alt="image1">\n'
+    )
+  })
+  it('should keep baseURL', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](https://localhost:3000/path/to/iamge1.jpg?w=300&blur=200)',
+        {
+          baseURL: 'https://localhost:3000',
+          keepBaseURL: true
+        }
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="https://localhost:3000/path/to/iamge1.jpg?w=300&#x26;blur=100" alt="image1">\n'
+    )
+  })
 })

--- a/test/image-salt.spec.ts
+++ b/test/image-salt.spec.ts
@@ -55,14 +55,22 @@ describe('remarkImageSalt', () => {
       '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" :modifiers="{&#x22;blur&#x22;:&#x22;100&#x22;}"></nuxt-img>\n'
     )
   })
-  it('should generate nuxt-img tag', async () => {
+  it('should replace query parameter', async () => {
     expect(
       await f(
-        '# test\n## test1\nimage-salt-1\n\n![image1#d:300x200 class="light-img" sizes="sm:100vw md:50vw lg:400px"#](/path/to/iamge1.jpg)',
-        { tagName: 'nuxt-img' }
+        '# test\n## test1\nimage-salt-1\n\n![image1#qq="blur=100"#](/path/to/iamge1.jpg?w=300)'
       )
     ).toEqual(
-      '# test\n\n## test1\n\nimage-salt-1\n\n<nuxt-img src="/path/to/iamge1.jpg" alt="image1" width="300" height="200" class="light-img" sizes="sm:100vw md:50vw lg:400px"></nuxt-img>\n'
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg?blur=100" alt="image1">\n'
+    )
+  })
+  it('should merge query parameter', async () => {
+    expect(
+      await f(
+        '# test\n## test1\nimage-salt-1\n\n![image1#q="blur=100"#](/path/to/iamge1.jpg?w=300&blur=200)'
+      )
+    ).toEqual(
+      '# test\n\n## test1\n\nimage-salt-1\n\n<img src="/path/to/iamge1.jpg?w=300&#x26;blur=100" alt="image1">\n'
     )
   })
 })

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -1,0 +1,23 @@
+import { decodeBase64Url, toModifiers } from '../src/query'
+
+describe('decodeBase64Url()', () => {
+  it('should decode base64 url string', async () => {
+    expect(decodeBase64Url('Zm9jYWxwb2ludA')).toEqual('focalpoint')
+  })
+})
+
+describe('toModifiers()', () => {
+  it('should convert query to modifiers', async () => {
+    expect(
+      toModifiers(
+        'auto=compress%2Cformat&crop64=Zm9jYWxwb2ludA&fit64=Y3JvcA&fp-x64=MC42&fp-z64=MS4z'
+      )
+    ).toEqual({
+      auto: 'compress,format',
+      crop: 'focalpoint',
+      fit: 'crop',
+      'fp-x': '0.6',
+      'fp-z': '1.3'
+    })
+  })
+})

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -1,0 +1,23 @@
+import { trimBaseURL } from '../src/util.js'
+
+describe('trimBaseURL()', () => {
+  it('should trim url by baseURL', async () => {
+    expect(
+      trimBaseURL(
+        'https://localhost:3000',
+        'https://localhost:3000/path/to/image.jpg'
+      )
+    ).toEqual('/path/to/image.jpg')
+    expect(
+      trimBaseURL(
+        'https://localhost:3000/',
+        'https://localhost:3000/path/to/image.jpg'
+      )
+    ).toEqual('/path/to/image.jpg')
+  })
+  it('should return url if baseURL is blank', async () => {
+    expect(trimBaseURL('', 'https://localhost:3000/path/to/image.jpg')).toEqual(
+      'https://localhost:3000/path/to/image.jpg'
+    )
+  })
+})


### PR DESCRIPTION
- Setup vscode debugger
- Make image-salt.ts
- Implement cli
- Make alt-attr.ts
- Use remarkFrontmatter in cli
- Make query.ts
- Edit quqery prameter of a image url by "qq"/"q" atribute
- Remove unused import
- Add --base-url and --keep-base-url flags
- Add --base-attrs falg
- Pass baseURL to editQuery
- Accept undefiend field in cli opts
- Use decodeAttrs() instead of attr() to decode base attrs
- Link to large image when "thumb" attar passed
- Remove unused line
- Typo "iamge" to "image"
